### PR TITLE
Allow randomly select an option

### DIFF
--- a/Fun GenTests/Fun_GenTests.swift
+++ b/Fun GenTests/Fun_GenTests.swift
@@ -184,8 +184,6 @@ class Fun_GenTests: XCTestCase {
     }
     
     func testActivityViewModelRandomSelection() async throws {
-        let beforeSelection = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
-        XCTAssertNil(beforeSelection)
         let selected = try await ActivityViewModel.selectRandomOption(forActivity: IDs.Activity.testActivity)
         let afterSelection = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
         XCTAssertEqual(selected, IDs.Option.testOption)

--- a/Fun GenTests/Fun_GenTests.swift
+++ b/Fun GenTests/Fun_GenTests.swift
@@ -184,13 +184,15 @@ class Fun_GenTests: XCTestCase {
     }
     
     func testActivityViewModelRandomSelection() async throws {
+        addTeardownAsync {
+            try await ActivityViewModel._vetoSelectedOption(forActivity: IDs.Activity.testActivity)
+        }
+        let beforeSelection = try await ActivityViewModel
+            .activity(id: IDs.Activity.testActivity)
+            .selectedOption
+        XCTAssertNil(beforeSelection)
         let selected = try await ActivityViewModel.selectRandomOption(forActivity: IDs.Activity.testActivity)
-        let afterSelection = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
         XCTAssertEqual(selected, IDs.Option.testOption)
-        XCTAssertEqual(afterSelection, IDs.Option.testOption)
-        try await ActivityViewModel._vetoSelectedOption(forActivity: IDs.Activity.testActivity)
-        let afterVeto = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
-        XCTAssertNil(afterVeto)
     }
     
     func testOptionViewModel() async throws {

--- a/Fun GenTests/Fun_GenTests.swift
+++ b/Fun GenTests/Fun_GenTests.swift
@@ -183,6 +183,18 @@ class Fun_GenTests: XCTestCase {
         XCTAssert(optionWithOutVote?.members.contains(IDs.User.testTest) == false)
     }
     
+    func testActivityViewModelRandomSelection() async throws {
+        let beforeSelection = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
+        XCTAssertNil(beforeSelection)
+        let selected = try await ActivityViewModel.selectRandomOption(forActivity: IDs.Activity.testActivity)
+        let afterSelection = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
+        XCTAssertEqual(selected, IDs.Option.testOption)
+        XCTAssertEqual(afterSelection, IDs.Option.testOption)
+        try await ActivityViewModel._vetoSelectedOption(forActivity: IDs.Activity.testActivity)
+        let afterVeto = try await ActivityViewModel.activity(id: IDs.Activity.testActivity).selectedOption
+        XCTAssertNil(afterVeto)
+    }
+    
     func testOptionViewModel() async throws {
         let randomText = "Test-\(#function)-\(UUID().uuidString)"
         let optionID = try OptionViewModel.createOption(title: randomText)

--- a/Shared/Model/Activity.swift
+++ b/Shared/Model/Activity.swift
@@ -29,6 +29,10 @@ struct Activity: Codable, Identifiable {
     /// Contains all ``PollOption``s suggested by ``members``, index by ``Option.ID``
     var options: [Option.ID: PollOption] = [:]
     
+    /// The ``Option.ID`` that won the vote by the members for this activity,
+    /// or nil if the voting hasn't concluded.
+    var selectedOption: Option.ID?
+    
     /// Sum of unique members who have voted for this ``Activity``
     var voteCount: Int {
         options.reduce(into: Set<User.ID>()) {

--- a/Shared/ViewModel/FunGenError.swift
+++ b/Shared/ViewModel/FunGenError.swift
@@ -7,5 +7,16 @@
 
 import Foundation
 
-enum FunGenError: Error {
+enum FunGenError: LocalizedError {
+    case activityHasNoOptionForRandomSelection
+    case activityAlreadyHasSelectedOption
+    
+    var errorDescription: String? {
+        switch self {
+        case .activityAlreadyHasSelectedOption:
+            return "The activity already has a selected option."
+        case .activityHasNoOptionForRandomSelection:
+            return "The activity has no option to randomly select from."
+        }
+    }
 }


### PR DESCRIPTION
- Add `selectedOption` of type `Option.ID?` to `Activity` to represent the option that won the vote
- Use `ActivityViewModel.selectRandomOption(forActivity:)` to randomly pick an option to become the selected option