### PR TITLE
Fixed Activity Creation with Blank Title

### DIFF
--- a/Shared/View/CreateActivityView.swift
+++ b/Shared/View/CreateActivityView.swift
@@ -98,6 +98,7 @@ struct CreateActivityView: View {
                 }
                 self.presentationMode.wrappedValue.dismiss()
             }, label: { Text("Create") })
+            .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             .alert("Unable to create activity", isPresented: $showingAlert) {
                 Button("OK") { }
             } message: {


### PR DESCRIPTION
Create button is greyed out until a user enters at least one non-whitespace character in the activity title field